### PR TITLE
Refactor drag and drop lists to avoid mutating Vue props

### DIFF
--- a/src/components/ParameterCard.vue
+++ b/src/components/ParameterCard.vue
@@ -1,7 +1,6 @@
 <template>
   <b-card no-body class="mb-1">
-    <parameter-item :parameterSet="parameterSet"
-                    :parameter="parameter"
+    <parameter-item :parameter="parameter"
                     :index="index"
                     @edit-parameter="onEditParameter($event)"
                     @reload-parameter-set="onReloadParameterSet"
@@ -24,7 +23,6 @@ import ValueListCardBody from './ValueListCardBody.vue';
 
 export default {
   props: {
-    parameterSet: Object,
     parameter: Object,
     index: Number,
   },

--- a/src/components/ParameterItemCardHeader.vue
+++ b/src/components/ParameterItemCardHeader.vue
@@ -37,7 +37,6 @@ import Config from './config';
 
 export default {
   props: {
-    parameterSet: Object,
     parameter: Object,
     index: Number,
   },

--- a/src/components/ParameterSet.vue
+++ b/src/components/ParameterSet.vue
@@ -1,12 +1,11 @@
 <template>
   <div>
     <h6 class="text-left">Parameters:</h6>
-    <draggable v-model="parameterSet.parameters" group="parameters"
+    <draggable v-model="parameterList" group="parameters" item-key="uid"
                @start="drag=true" @end="drag=false" @change="onDragChange($event)">
-      <div :key="pindex"
-           v-for="(parameter,pindex) in parameterSet.parameters" role="tablist">
-        <parameter-card :parameterSet="parameterSet"
-                        :parameter="parameter"
+      <div :key="parameter.uid"
+           v-for="(parameter,pindex) in parameterList" role="tablist">
+        <parameter-card :parameter="parameter"
                         :index="pindex"
                         @edit-parameter="$refs.editParameterForm.onEditParameter(parameter)"
                         @add-value="$refs.addValueForm.setParameter($event)"
@@ -50,6 +49,23 @@ export default {
   props: {
     parameterSet: Object,
   },
+  // Take a copy of the list of parameters to set up drag and
+  // drop for re-ordering parameters - mutating a prop directly
+  // is a Vue anti-pattern, and deprecated.
+  watch: {
+    parameterSet(newVal) {
+      if ('parameters' in newVal) {
+        this.parameterList = [...newVal.parameters];
+      } else {
+        this.parameterList = [];
+      }
+    },
+  },
+  data() {
+    return {
+      parameterList: [],
+    };
+  },
   components: {
     draggable,
     'parameter-card': ParameterCard,
@@ -68,7 +84,7 @@ export default {
     onDragChange(eventInfo) {
       if ('moved' in eventInfo) {
         const { oldIndex, newIndex } = eventInfo.moved;
-        const movedParameter = this.parameterSet.parameters[newIndex];
+        const movedParameter = this.parameterList[newIndex];
         this.moveParameter(movedParameter.name, oldIndex, newIndex);
       }
     },
@@ -90,6 +106,9 @@ export default {
           this.onReloadParameterSet();
         });
     },
+  },
+  created() {
+    this.parameterList = [...this.parameterSet.parameters];
   },
 };
 

--- a/src/components/ValueListCardBody.vue
+++ b/src/components/ValueListCardBody.vue
@@ -16,9 +16,9 @@
     </b-row>
     <hr>
     <ul class="list-group list-group-flush">
-    <draggable v-model="parameter.values" group="values"
+    <draggable v-model="valueList" group="values" item-key="uid"
                @start="drag=true" @end="drag=false" @change="onDragChange($event)">
-      <div :key="vindex" v-for="(value,vindex) in parameter.values" role="tablist">
+      <div :key="value.uid" v-for="(value,vindex) in valueList" role="tablist">
         <value-item :parameter="parameter"
                     :value="value"
                     :index="vindex"
@@ -47,6 +47,23 @@ export default {
     draggable,
     'value-item': ValueItem,
   },
+  // Take a copy of the list of values to set up drag and
+  // drop for re-ordering parameters - mutating a prop directly
+  // is a Vue anti-pattern, and deprecated.
+  watch: {
+    parameter(newVal) {
+      if ('values' in newVal) {
+        this.valueList = [...newVal.values];
+      } else {
+        this.ValueList = [];
+      }
+    },
+  },
+  data() {
+    return {
+      valueList: [],
+    };
+  },
   methods: {
     onAlertMessage(message) {
       this.$emit('alert-message', message);
@@ -63,7 +80,7 @@ export default {
     onDragChange(eventInfo) {
       if ('moved' in eventInfo) {
         const { oldIndex, newIndex } = eventInfo.moved;
-        const movedValue = this.parameter.values[newIndex];
+        const movedValue = this.valueList[newIndex];
         this.moveValue(this.parameter, movedValue.name, oldIndex, newIndex);
       }
     },
@@ -89,6 +106,9 @@ export default {
           this.onReloadParameterSet();
         });
     },
+  },
+  created() {
+    this.valueList = [...this.parameter.values];
   },
 };
 


### PR DESCRIPTION
Summary of changes:

- During a check of whether the project could be converted to Vue 3, a warning appeared during compile that mutating a prop is deprecated in Vue 2 and an error in Vue 3.  Using ``vuedraggable`` for drag-and-drop of reorderable lists mutated the parameter and value list props directly.
- Modified the components using ``vuedraggable`` to take copies of the lists where elements can be move around.  A shallow copy can be used, because if a drag-and-drop occurs, an call is made to the REST API to update the data and the parameter set is refreshed.
- Set the keys on the reorderable lists to use the ``uid`` object attribute to make sure that nested reorderable lists work with the copied lists.  It should have been done this way originally.
- Removed ``parameterSet`` as a prop in components that handle only single parameters.