### PR TITLE
Use bootstrap-vue components consistently

### DIFF
--- a/src/components/AboutTconfig.vue
+++ b/src/components/AboutTconfig.vue
@@ -1,47 +1,51 @@
 <template>
-  <div class="container text-left">
-    <h1 class="md">TConfig - Test Configuration Generator</h1>
-    <h2>Introduction</h2>
-    <p>
-      TConfig - the Test Configuration Generator - generates covering arrays for
-      combinatorial coverage of parameters with discrete values.  An instance of
-      this type of coverage is "pair-wise" coverage, which is that all pairs of
-      parameter values are covered in at least one test configuration.
-    </p>
-    <p>
-      For example,suppose that you had to test a Python program that offered a REST API
-      and a browser client (such as this one &#127773;), and cross-platform functionality is a
-      concern.  Here are four parameters of interest, and a set of values for each parameter.
-    </p>
-    <b-table size="sm" striped hover :items="parameters">
-    </b-table>
-    <hr>
-    <p>
-      Testing all possible combinations would require 3 &times; 4 &times; 4 &times; 3 = 144
-      configurations.
-    </p>
-    <p>
-      Suppose that it would be acceptable to include every pair-wise interaction
-      in some test configuration, but that it is unlikely that there would be some issue
-      that would only appear if there was a particular 3-way or 4-way combination of values.
-      Then, a covering array of degree 2 would suffice.
-    </p>
-    <p>
-      Here is a covering array of degree 2 for the above parameters and values.  It consists
-      of only 16 configurations. Note that not all values are specified, as coverage is achieved
-      without a particular value in some slot.  Of course, a value would typically need to be
-      provided to complete the configuration, but any value will do.
-    </p>
-    <p>
-      To check pair-wise coverage:  deselect columns until there are 2 columns left.  Verify
-      that all possible combinations of the values for those 2 columns are contained within (at
-      least one) configuration.
-    </p>
-    <b-row class="col-sm-12">
-      <b-col class="col-sm-4 font-weight-bold">
+  <b-container>
+    <b-row>
+      <b-col cols="12" class="text-left">
+        <h1 class="md text-center">TConfig - Test Configuration Generator</h1>
+        <h2>Introduction</h2>
+        <p>
+          TConfig - the Test Configuration Generator - generates covering arrays for
+          combinatorial coverage of parameters with discrete values.  An instance of
+          this type of coverage is "pair-wise" coverage, which is that all pairs of
+          parameter values are covered in at least one test configuration.
+        </p>
+        <p>
+          For example,suppose that you had to test a Python program that offered a REST API
+          and a browser client (such as this one &#127773;), and cross-platform functionality is a
+          concern.  Here are four parameters of interest, and a set of values for each parameter.
+        </p>
+        <b-table size="sm" striped hover :items="parameters">
+        </b-table>
+        <hr>
+        <p>
+          Testing all possible combinations would require 3 &times; 4 &times; 4 &times; 3 = 144
+          configurations.
+        </p>
+        <p>
+          Suppose that it would be acceptable to include every pair-wise interaction
+          in some test configuration, but that it is unlikely that there would be some issue
+          that would only appear if there was a particular 3-way or 4-way combination of values.
+          Then, a covering array of degree 2 would suffice.
+        </p>
+        <p>
+          Here is a covering array of degree 2 for the above parameters and values.  It consists
+          of only 16 configurations. Note that not all values are specified, as coverage is achieved
+          without a particular value in some slot.  Of course, a value would typically need to be
+          provided to complete the configuration, but any value will do.
+        </p>
+        <p>
+          To check pair-wise coverage:  deselect columns until there are 2 columns left.  Verify
+          that all possible combinations of the values for those 2 columns are contained within (at
+          least one) configuration.
+        </p>
+      </b-col>
+    </b-row>
+    <b-row size="sm">
+      <b-col cols="4" class="text-right font-weight-bold">
         Show columns:
       </b-col>
-      <b-col class="col">
+      <b-col>
         <b-checkbox
         :disabled="visibleFields.length == 2 && field.visible"
         v-for="field in configFields"
@@ -59,7 +63,7 @@
       (***) - Any value can be used in these configurations; specific values are not needed
       for coverage purposes.
     </p>
-  </div>
+  </b-container>
 </template>
 
 <script>

--- a/src/components/AddParameterForm.vue
+++ b/src/components/AddParameterForm.vue
@@ -3,7 +3,7 @@
            id="add-parameter-form"
            title="Add a new parameter"
            hide-footer>
-    <b-form @submit="onSubmitAddParameter" @reset="onResetAddParameter" class="w-100">
+    <b-form @submit="onSubmitAddParameter" @reset="onResetAddParameter">
       <b-form-group id="form-add-parameter-name-group"
                     label="Name:"
                     label-for="form-add-parameter-name-input">

--- a/src/components/AddValueForm.vue
+++ b/src/components/AddValueForm.vue
@@ -3,7 +3,7 @@
            id="add-value-form"
            title="Add a new value"
            hide-footer>
-    <b-form @submit="onSubmitAddValue" @reset="onResetAddValue" class="w-100">
+    <b-form @submit="onSubmitAddValue" @reset="onResetAddValue">
       <b-form-group id="form-add-value-name-group"
                     label="Name:"
                     label-for="form-add-value-name-input">

--- a/src/components/Configurations.vue
+++ b/src/components/Configurations.vue
@@ -1,31 +1,35 @@
 <template>
-  <div class="container">
-    <div class="col-sm-12">
-      <b-row>
-        <b-col class="col-sm-6 text-right">
-          <label>Configurations per page</label>
-        </b-col>
-        <b-col class="col-sm-2">
-          <b-form-select class="w-10" v-model="perPage"
+  <b-container class="col-sm-12">
+    <b-row>
+      <b-col cols="6" class="text-right">
+        <label>Configurations per page</label>
+      </b-col>
+      <b-col cols="2">
+        <b-form-select class="w-10" v-model="perPage"
                          :options="options">
-          </b-form-select>
-        </b-col>
-      </b-row>
-    </div>
+        </b-form-select>
+      </b-col>
+    </b-row>
     <p></p>
-    <b-table size="sm" striped hover bordered :items="configurations"
-             :current-page="currentPage" :per-page="perPage">
-    </b-table>
-    <div class="justify-content-center row my-0">
-      <b-pagination size="sm" :total-rows="configurations.length"
-                    :per-page="perPage" v-model="currentPage"/>
-    </div>
+    <b-row>
+      <b-col>
+        <b-table size="sm" striped hover bordered :items="configurations"
+                 :current-page="currentPage" :per-page="perPage">
+        </b-table>
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col cols="12">
+        <b-pagination size="sm" :total-rows="configurations.length" align="center"
+                      :per-page="perPage" v-model="currentPage"/>
+        </b-col>
+    </b-row>
     <generate-configurations-form ref="generateConfigurationsForm"
                                   :parameterSet="parameterSet"
                                   @configurations-generated="configurationsGenerated($event)"
                                   @alert-message="alertMessage($event)">
     </generate-configurations-form>
-  </div>
+  </b-container>
 </template>
 
 <script>

--- a/src/components/Configurations.vue
+++ b/src/components/Configurations.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-container class="col-sm-12">
+  <b-container sm="12">
     <b-row>
-      <b-col cols="6" class="text-right">
+      <b-col cols="6" align-h="text-right">
         <label>Configurations per page</label>
       </b-col>
       <b-col cols="2">

--- a/src/components/EditParameterForm.vue
+++ b/src/components/EditParameterForm.vue
@@ -3,7 +3,7 @@
            id="edit-parameter-form"
            title="Edit parameter"
            hide-footer>
-    <b-form @submit="onSubmitEditParameter" @reset="onResetEditParameter" class="w-100">
+    <b-form @submit="onSubmitEditParameter" @reset="onResetEditParameter">
       <b-form-group id="form-edit-parameter-name-group"
                     label="Name:"
                     label-for="form-edit-parameter-name-input">

--- a/src/components/EditValueForm.vue
+++ b/src/components/EditValueForm.vue
@@ -3,7 +3,7 @@
            id="edit-value-form"
            title="Edit value"
            hide-footer>
-    <b-form @submit="onSubmitEditValue" @reset="onResetEditValue" class="w-100">
+    <b-form @submit="onSubmitEditValue" @reset="onResetEditValue">
       <b-form-group id="form-edit-value-name-group"
                     label="Name:"
                     label-for="form-edit-value-name-input">

--- a/src/components/GenerateConfigurationsForm.vue
+++ b/src/components/GenerateConfigurationsForm.vue
@@ -4,7 +4,7 @@
       id="generate_configurations-form"
       title="Generate Configurations"
       hide-footer>
-    <b-form @submit="onSubmitGenerateForm" @reset="onResetGenerateForm" class="w-100">
+    <b-form @submit="onSubmitGenerateForm" @reset="onResetGenerateForm">
       <b-form-group id="form-generate-configs-algorithm-group"
                     label="Generation algorithm:"
                     label-for="form-generate-configs-algorithm-input">

--- a/src/components/ParameterCard.vue
+++ b/src/components/ParameterCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-card no-body class="mb-1">
+  <b-card no-body>
     <parameter-item :parameter="parameter"
                     :index="index"
                     @edit-parameter="onEditParameter($event)"

--- a/src/components/ParameterItemCardHeader.vue
+++ b/src/components/ParameterItemCardHeader.vue
@@ -1,19 +1,19 @@
 <template>
   <b-card-header header-tag="header" class="p-1" role="tab">
     <b-row>
-      <b-col class="col-6">
+      <b-col cols="6">
         <b-button size="sm" block href="#" v-b-toggle="'accordion-' + index"
                   variant="outline-secondary">{{parameter.name}} -
           {{parameter.values.length}} values
         </b-button>
       </b-col>
       <b-col>
-        <b-button pill variant="outline-dark" size="sm" class="mr-2">
+        <b-button pill variant="outline-dark" size="sm">
           <b-icon icon="arrow-down-up" aria-hidden="true"></b-icon> Drag to reorder
         </b-button>
       </b-col>
       <b-col>
-        <div class="btn-group" role="group">
+        <b-button-group>
           <b-button pill variant="warning" size="sm" class="mr-2"
                     v-b-modal.edit-parameter-form
                     @click="onEditParameter">
@@ -25,7 +25,7 @@
             <b-icon icon="trash" aria-hidden="true"></b-icon>
             Delete
           </b-button>
-        </div>
+        </b-button-group>
       </b-col>
     </b-row>
   </b-card-header>

--- a/src/components/ParameterSet.vue
+++ b/src/components/ParameterSet.vue
@@ -1,19 +1,18 @@
 <template>
-  <div>
+  <b-container>
     <h6 class="text-left">Parameters:</h6>
     <draggable v-model="parameterList" group="parameters" item-key="uid"
                @start="drag=true" @end="drag=false" @change="onDragChange($event)">
-      <div :key="parameter.uid"
-           v-for="(parameter,pindex) in parameterList" role="tablist">
-        <parameter-card :parameter="parameter"
-                        :index="pindex"
-                        @edit-parameter="$refs.editParameterForm.onEditParameter(parameter)"
-                        @add-value="$refs.addValueForm.setParameter($event)"
-                        @edit-value="$refs.editValueForm.onEditValue($event)"
-                        @reload-parameter-set="onReloadParameterSet"
-                        @alert-message="onAlertMessage($event)">
-        </parameter-card>
-      </div>
+      <parameter-card :key="parameter.uid"
+                      v-for="(parameter,pindex) in parameterList" role="tablist"
+                      :parameter="parameter"
+                      :index="pindex"
+                      @edit-parameter="$refs.editParameterForm.onEditParameter(parameter)"
+                      @add-value="$refs.addValueForm.setParameter($event)"
+                      @edit-value="$refs.editValueForm.onEditValue($event)"
+                      @reload-parameter-set="onReloadParameterSet"
+                      @alert-message="onAlertMessage($event)">
+      </parameter-card>
     </draggable>
     <add-parameter-form ref="addParameterForm"
                         @alert-message="onAlertMessage($event)"
@@ -31,7 +30,7 @@
                      @alert-message="onAlertMessage($event)"
                      @reload-parameter-set="onReloadParameterSet">
     </edit-value-form>
-  </div>
+  </b-container>
 </template>
 
 <script>

--- a/src/components/Tconfig.vue
+++ b/src/components/Tconfig.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container class="col-sm-12">
+  <b-container sm>
     <h4>Test Configuration Generator</h4>
     <alert size="sm" show :message=message v-if="showMessage"></alert>
     <b-row>

--- a/src/components/Tconfig.vue
+++ b/src/components/Tconfig.vue
@@ -1,37 +1,33 @@
 <template>
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-12">
-        <h4>Test Configuration Generator</h4>
-        <alert size="sm" show :message=message v-if="showMessage"></alert>
-        <b-row>
-          <b-col>
-            <b-button pill variant="success" size="sm" v-b-modal.add-parameter-form>
-              <b-icon icon="plus-square-fill" aria-hidden="true" font-scale="1.5">
-              </b-icon>
-              Add Parameter
-            </b-button>
-          </b-col>
-          <b-col>
-            <b-button pill variant="info" size="sm" v-b-modal.generate_configurations-form>
-              <b-icon icon="play-fill" aria-hidden="true" font-scale="1.5">
-              </b-icon>
-              Generate Configurations
-            </b-button>
-          </b-col>
-        </b-row>
-        <hr>
-        <parameter-set :parameterSet="parameterSet"
-                       @alert-message="onAlertMessage($event)"
-                       @reload-parameter-set="getParameterSet($event)">
-        </parameter-set>
-      </div>
-    </div>
+  <b-container class="col-sm-12">
+    <h4>Test Configuration Generator</h4>
+    <alert size="sm" show :message=message v-if="showMessage"></alert>
+    <b-row>
+      <b-col cols="6">
+        <b-button pill variant="success" size="sm" v-b-modal.add-parameter-form>
+          <b-icon icon="plus-square-fill" aria-hidden="true" font-scale="1.5">
+          </b-icon>
+          Add Parameter
+        </b-button>
+      </b-col>
+      <b-col cols="5">
+        <b-button pill variant="info" size="sm" v-b-modal.generate_configurations-form>
+          <b-icon icon="play-fill" aria-hidden="true" font-scale="1.5">
+          </b-icon>
+          Generate Configurations
+        </b-button>
+      </b-col>
+    </b-row>
+    <hr>
+    <parameter-set :parameterSet="parameterSet"
+                   @alert-message="onAlertMessage($event)"
+                   @reload-parameter-set="getParameterSet($event)">
+    </parameter-set>
     <hr>
     <configurations :parameterSet="parameterSet"
                     @alert-message="onAlertMessage($event)">
     </configurations>
-  </div>
+  </b-container>
 </template>
 
 <script>

--- a/src/components/ValueItem.vue
+++ b/src/components/ValueItem.vue
@@ -1,14 +1,14 @@
 <template>
-  <li class="list-group-item">
+  <b-list-group-item>
     <b-row size="sm">
       <b-col>{{value.name}}</b-col>
       <b-col>
-        <b-button pill variant="outline-info" size="sm" class="mr-2">
+        <b-button pill variant="outline-dark" size="sm">
           <b-icon icon="arrow-down-up" aria-hidden="true"></b-icon>
         </b-button>
       </b-col>
       <b-col>
-        <div class="btn-group" role="group">
+        <b-button-group>
           <b-button pill variant="warning" size="sm" class="mr-2"
                     v-b-modal.edit-value-form
                     @click="onEditValue">
@@ -18,10 +18,10 @@
                     @click="onDeleteValue(parameter, value)">
             <b-icon icon="trash" aria-hidden="true"></b-icon>
           </b-button>
-        </div>
+        </b-button-group>
       </b-col>
     </b-row>
-  </li>
+  </b-list-group-item>
 </template>
 
 <script>

--- a/src/components/ValueListCardBody.vue
+++ b/src/components/ValueListCardBody.vue
@@ -1,10 +1,10 @@
 <template>
   <b-card-body>
-    <b-row class="row align-items-start">
-      <b-col class="col-sm-1">
+    <b-row class="align-items-start">
+      <b-col cols="1">
         <p>Values</p>
       </b-col>
-      <b-col class="col-sm-6">
+      <b-col cols="6">
         <b-button pill variant="success" size="sm"
                   v-b-modal.add-value-form
                   @click="onAddValue">
@@ -15,20 +15,21 @@
       </b-col>
     </b-row>
     <hr>
-    <ul class="list-group list-group-flush">
-    <draggable v-model="valueList" group="values" item-key="uid"
-               @start="drag=true" @end="drag=false" @change="onDragChange($event)">
-      <div :key="value.uid" v-for="(value,vindex) in valueList" role="tablist">
-        <value-item :parameter="parameter"
+    <b-list-group flush>
+      <draggable v-model="valueList" group="values" item-key="uid"
+                 @start="drag=true" @end="drag=false" @change="onDragChange($event)">
+        <value-item :key="value.uid"
+                    v-for="(value,vindex) in valueList"
+                    role="tablist"
+                    :parameter="parameter"
                     :value="value"
                     :index="vindex"
                     @edit-value="onEditValue($event)"
                     @reload-parameter-set="onReloadParameterSet"
                     @alert-message="onAlertMessage($event)">
         </value-item>
-      </div>
-    </draggable>
-    </ul>
+      </draggable>
+    </b-list-group>
   </b-card-body>
 </template>
 

--- a/src/components/ValueListCardBody.vue
+++ b/src/components/ValueListCardBody.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card-body>
-    <b-row class="align-items-start">
+    <b-row align-h="start">
       <b-col cols="1">
         <p>Values</p>
       </b-col>


### PR DESCRIPTION
Summary of changes:

- Some HTML tags were left over as cut-and-pasted from the sample project used to learn about Vue.js.  Now that I've learned more about Bootstrap-Vue, update the HTML to consistently use Bootstrap-Vue components, instead of using ``<div>`` tags that borrow Bootstrap-Vue CSS classes.