### PR TITLE
Parameter set unit tests and resulting updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.editorconfig
 /.idea/
+/.vs/
 /.settings/
 /debug.log
 /node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7014,6 +7014,12 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
+      "dev": true
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-vue": "^6.2.2",
+    "flush-promises": "^1.0.2",
     "vue-template-compiler": "^2.6.11"
   },
   "eslintConfig": {

--- a/src/components/Configurations.vue
+++ b/src/components/Configurations.vue
@@ -24,8 +24,7 @@
                       :per-page="perPage" v-model="currentPage"/>
         </b-col>
     </b-row>
-    <generate-configurations-form ref="generateConfigurationsForm"
-                                  :parameterSet="parameterSet">
+    <generate-configurations-form ref="generateConfigurationsForm">
     </generate-configurations-form>
   </b-container>
 </template>
@@ -34,9 +33,6 @@
 import GenerateConfigurationsForm from './GenerateConfigurationsForm.vue';
 
 export default {
-  props: {
-    parameterSet: Object,
-  },
   computed: {
     configurationSet() {
       return this.$store.getters.configurationSet;

--- a/src/components/GenerateConfigurationsForm.vue
+++ b/src/components/GenerateConfigurationsForm.vue
@@ -35,9 +35,6 @@
 import apiMixin from '../mixins/rest_api';
 
 export default {
-  props: {
-    parameterSet: Object,
-  },
   mixins: [apiMixin],
   data() {
     return {
@@ -60,7 +57,8 @@ export default {
       evt.preventDefault();
       this.$refs.generateConfigurationsForm.hide();
       // Next line function in 'apiMixin'
-      this.apiGenerateConfigurations(this.parameterSet, this.form.algorithmName,
+      this.apiGenerateConfigurations(this.$store.getters.parameterSet,
+        this.form.algorithmName,
         this.form.coverageDegree);
       this.initForm();
     },

--- a/src/components/ParameterSet.vue
+++ b/src/components/ParameterSet.vue
@@ -30,8 +30,10 @@ import AddValueForm from './AddValueForm.vue';
 import EditValueForm from './EditValueForm.vue';
 
 export default {
-  props: {
-    parameterSet: Object,
+  computed: {
+    parameterSet() {
+      return this.$store.getters.parameterSet;
+    },
   },
   // Take a copy of the list of parameters to set up drag and
   // drop for re-ordering parameters - mutating a prop directly
@@ -68,6 +70,9 @@ export default {
         this.apiMoveParameter(movedParameter.name, oldIndex, newIndex);
       }
     },
+  },
+  created() {
+    this.apiGetParameterSet();
   },
 };
 

--- a/src/components/Tconfig.vue
+++ b/src/components/Tconfig.vue
@@ -19,27 +19,19 @@
       </b-col>
     </b-row>
     <hr>
-    <parameter-set :parameterSet="parameterSet">
-    </parameter-set>
+    <parameter-set></parameter-set>
     <hr>
-    <configurations :parameterSet="parameterSet">
-    </configurations>
+    <configurations> </configurations>
   </b-container>
 </template>
 
 <script>
-import apiMixin from '../mixins/rest_api';
-
 import Status from './Status.vue';
 import ParameterSet from './ParameterSet.vue';
 import Configurations from './Configurations.vue';
 
 export default {
-  mixins: [apiMixin],
   computed: {
-    parameterSet() {
-      return this.$store.getters.parameterSet;
-    },
     status() {
       return this.$store.getters.status;
     },
@@ -48,9 +40,6 @@ export default {
     status: Status,
     'parameter-set': ParameterSet,
     configurations: Configurations,
-  },
-  created() {
-    this.apiGetParameterSet();
   },
 };
 

--- a/src/components/ValueListCardBody.vue
+++ b/src/components/ValueListCardBody.vue
@@ -1,10 +1,10 @@
 <template>
   <b-card-body>
     <b-row align-h="start">
-      <b-col cols="1">
+      <b-col>
         <p>Values</p>
       </b-col>
-      <b-col cols="6">
+      <b-col>
         <b-button pill variant="success" size="sm"
                   v-b-modal.add-value-form
                   @click="addValueForm.setParameter(parameter)">

--- a/src/mixins/rest_api.js
+++ b/src/mixins/rest_api.js
@@ -16,9 +16,13 @@ const restApi = {
       this.$store.commit('setStatus', statusInfo);
     },
     axiosError(error) {
-      this.setStatus(error, 'danger');
+      if ('message' in error) {
+        this.setStatus(error.message, 'danger');
+      } else {
+        this.setStatus('An error occurred during API call', 'danger');
+      }
       // eslint-disable-next-line
-      console.error(error);
+      console.error(error.toJSON());
     },
     apiGetParameterSet() {
       axios.get(PARAMETER_SET_URL)

--- a/tests/unit/parameter_set.spec.js
+++ b/tests/unit/parameter_set.spec.js
@@ -1,0 +1,420 @@
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue/dist/bootstrap-vue.css';
+import Vuex from 'vuex';
+import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
+import { expect } from 'chai';
+import { createLocalVue, mount } from '@vue/test-utils';
+import axios from 'axios';
+import AxiosMockAdapter from 'axios-mock-adapter';
+import ParameterSet from '@/components/ParameterSet.vue';
+import ParameterCard from '@/components/ParameterCard.vue';
+import AddParameterForm from '@/components/AddParameterForm.vue';
+import EditParameterForm from '@/components/EditParameterForm.vue';
+import AddValueForm from '@/components/AddValueForm.vue';
+import EditValueForm from '@/components/EditValueForm.vue';
+import state from '@/store/state';
+import getters from '@/store/getters';
+import mutations from '@/store/mutations';
+import draggable from 'vuedraggable';
+import flushPromises from 'flush-promises';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(BootstrapVue);
+localVue.use(IconsPlugin);
+
+const API_PREFIX = 'http://localhost:5000/tconfig/api/v1/';
+const PARAMETER_SET_URL = API_PREFIX.concat('parameterset/');
+const PARAMETER_URL = API_PREFIX.concat('parameters/');
+
+const MOCK_PARAMETER_SET = {
+  name: null,
+  parameters: [
+    {
+      excluded: [],
+      excluded_by: [],
+      name: 'Colour',
+      parameter_set: 1,
+      position: 0,
+      uid: 1,
+      values: [
+        {
+          name: 'Red',
+          parameter: 1,
+          position: 0,
+          uid: 1,
+        },
+        {
+          name: 'Green',
+          parameter: 1,
+          position: 1,
+          uid: 2,
+        },
+      ],
+    },
+    {
+      excluded: [],
+      excluded_by: [],
+      name: 'Pet',
+      parameter_set: 1,
+      position: 1,
+      uid: 2,
+      values: [
+        {
+          name: 'Bird',
+          parameter: 2,
+          position: 0,
+          uid: 3,
+        },
+        {
+          name: 'Cat',
+          parameter: 2,
+          position: 1,
+          uid: 4,
+        },
+        {
+          name: 'Dog',
+          parameter: 2,
+          position: 2,
+          uid: 5,
+        },
+        {
+          name: 'Fish',
+          parameter: 2,
+          position: 3,
+          uid: 6,
+        },
+      ],
+    },
+  ],
+  position: null,
+  uid: 1,
+};
+
+const MOCK_DATA = {
+  parameter_list_url: PARAMETER_URL,
+  parameter_set: MOCK_PARAMETER_SET,
+  parameter_set_url: PARAMETER_SET_URL,
+};
+
+describe('ParameterSet.vue', () => {
+  let wrapper;
+  let store;
+  let mock;
+
+  beforeEach(() => {
+    mock = new AxiosMockAdapter(axios);
+    mock.onGet(PARAMETER_SET_URL).reply(200, MOCK_DATA);
+    mock.onPut(PARAMETER_URL).reply(200, {});
+    store = new Vuex.Store({
+      state,
+      getters,
+      mutations,
+    });
+    wrapper = mount(ParameterSet, {
+      store,
+      localVue,
+    });
+  });
+
+  afterEach(() => {
+    mock.restore();
+    const statusInfo = {
+      message: 'Welcome',
+      variant: 'info',
+    };
+    store.commit('setStatus', statusInfo);
+  });
+
+  it('should have 1 add parameter form component', () => {
+    const psets = wrapper.findAllComponents(AddParameterForm);
+    expect(psets.length).to.equal(1);
+    expect(psets.is(AddParameterForm)).to.equal(true);
+  });
+
+  it('should have 1 edit parameter form component', () => {
+    const configs = wrapper.findAllComponents(EditParameterForm);
+    expect(configs.length).to.equal(1);
+    expect(configs.is(EditParameterForm)).to.equal(true);
+  });
+
+  it('should have 1 add value form component', () => {
+    const psets = wrapper.findAllComponents(AddValueForm);
+    expect(psets.length).to.equal(1);
+    expect(psets.is(AddValueForm)).to.equal(true);
+  });
+
+  it('should have 1 edit value form component', () => {
+    const configs = wrapper.findAllComponents(EditValueForm);
+    expect(configs.length).to.equal(1);
+    expect(configs.is(EditValueForm)).to.equal(true);
+  });
+
+  it('should load a parameter set on creation', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    expect(mock.history.get.length).to.equal(1);
+    expect(mock.history.get[0].url).to.equal(PARAMETER_SET_URL);
+    // Now wait for API response
+    await localVue.nextTick();
+    // Expect that the 'parameter_set' attribute of response is stored.
+    // Check object equivalence, not identity
+    expect(wrapper.vm.parameterSet).to.eql(MOCK_DATA.parameter_set);
+    // eslint-disable-next-line
+  });
+
+  it('should have 2 parameter card components after loading 2 parameters', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    expect(mock.history.get.length).to.equal(1);
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    // Mock data has 2 parameters
+    const pcards = wrapper.findAllComponents(ParameterCard);
+    expect(pcards.length).to.equal(2);
+    expect(pcards.is(ParameterCard)).to.equal(true);
+  });
+
+  it('should show the parameter names and number of values', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    expect(mock.history.get.length).to.equal(1);
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    // Mock data has 2 parameters
+    const colourMsg = 'Colour - 2 values';
+    expect(wrapper.text()).to.include(colourMsg);
+    const petMsg = 'Pet - 4 values';
+    expect(wrapper.text()).to.include(petMsg);
+  });
+
+  it('should have 3 draggable components after loading 2 parameters', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    expect(mock.history.get.length).to.equal(1);
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    // One draggable for parameter list, one draggable for each of
+    // two value lists.
+    const dragndrop = wrapper.findAllComponents(draggable);
+    expect(dragndrop.length).to.equal(3);
+  });
+
+  it('should call PUT on /parameters when parameter moved', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    const parameterDraggable = wrapper.findComponent(draggable);
+    expect(mock.history.put.length).to.equal(0);
+    const changeData = {
+      moved: {
+        element: wrapper.vm.parameterSet.parameters[0],
+        oldIndex: 0,
+        newIndex: 1,
+      },
+    };
+    parameterDraggable.vm.$emit('change', changeData);
+    await localVue.nextTick();
+    expect(mock.history.put.length).to.equal(1);
+    const expectedApiData = {
+      oldIndex: 0,
+      newIndex: 1,
+    };
+    expect(mock.history.put[0].url).to.equal(PARAMETER_URL);
+    expect(mock.history.put[0].data).to.equal(JSON.stringify(expectedApiData));
+  });
+
+  it('should update status when parameter moved', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    const parameterDraggable = wrapper.findComponent(draggable);
+    const changeData = {
+      moved: {
+        element: wrapper.vm.parameterSet.parameters[0],
+        oldIndex: 0,
+        newIndex: 1,
+      },
+    };
+    parameterDraggable.vm.$emit('change', changeData);
+    // Await API call
+    await localVue.nextTick();
+    const beforeExpectedStatus = {
+      message: 'Welcome',
+      variant: 'info',
+    };
+    expect(store.getters.status).to.eql(beforeExpectedStatus);
+    // Render after API response
+    await localVue.nextTick();
+    const afterExpectedStatus = {
+      message: 'Parameter "Pet" moved from position 0 to 1',
+      variant: 'success',
+    };
+    expect(store.getters.status).to.eql(afterExpectedStatus);
+  });
+
+  it('should ignore vuedraggable "added" event', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    const parameterDraggable = wrapper.findComponent(draggable);
+    expect(mock.history.put.length).to.equal(0);
+    const changeData = {
+      added: {
+        element: wrapper.vm.parameterSet.parameters[0],
+        newIndex: 0,
+      },
+    };
+    parameterDraggable.vm.$emit('change', changeData);
+    await localVue.nextTick();
+    // Should not trigger an API call
+    expect(mock.history.put.length).to.equal(0);
+  });
+
+  it('should ignore vuedraggable "removed" event', async () => {
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    const parameterDraggable = wrapper.findComponent(draggable);
+    expect(mock.history.put.length).to.equal(0);
+    const changeData = {
+      removed: {
+        element: wrapper.vm.parameterSet.parameters[0],
+        oldIndex: 0,
+      },
+    };
+    parameterDraggable.vm.$emit('change', changeData);
+    await localVue.nextTick();
+    // Should not trigger an API call
+    expect(mock.history.put.length).to.equal(0);
+  });
+
+  it('should show error message on API call network error', async () => {
+    mock.restore();
+    mock = new AxiosMockAdapter(axios);
+    mock.onGet(PARAMETER_SET_URL).reply(200, MOCK_DATA);
+    mock.onPut(PARAMETER_URL).networkError();
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    const parameterDraggable = wrapper.findComponent(draggable);
+    expect(mock.history.put.length).to.equal(0);
+    const changeData = {
+      moved: {
+        element: wrapper.vm.parameterSet.parameters[0],
+        oldIndex: 0,
+        newIndex: 1,
+      },
+    };
+    parameterDraggable.vm.$emit('change', changeData);
+    // Await API call
+    await localVue.nextTick();
+    const beforeExpectedStatus = {
+      message: 'Welcome',
+      variant: 'info',
+    };
+    expect(store.getters.status).to.eql(beforeExpectedStatus);
+    // Render after API response
+    await flushPromises();
+    const afterExpectedStatus = {
+      message: 'Network Error',
+      variant: 'danger',
+    };
+    expect(store.getters.status).to.deep.include(afterExpectedStatus);
+  });
+
+  it('should show error message on API call timeout', async () => {
+    mock.restore();
+    mock = new AxiosMockAdapter(axios);
+    mock.onGet(PARAMETER_SET_URL).reply(200, MOCK_DATA);
+    mock.onPut(PARAMETER_URL).timeout();
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    const parameterDraggable = wrapper.findComponent(draggable);
+    expect(mock.history.put.length).to.equal(0);
+    const changeData = {
+      moved: {
+        element: wrapper.vm.parameterSet.parameters[0],
+        oldIndex: 0,
+        newIndex: 1,
+      },
+    };
+    parameterDraggable.vm.$emit('change', changeData);
+    // Await API call
+    await localVue.nextTick();
+    const beforeExpectedStatus = {
+      message: 'Welcome',
+      variant: 'info',
+    };
+    expect(store.getters.status).to.eql(beforeExpectedStatus);
+    // Render after API response
+    await flushPromises();
+    const afterExpectedStatus = {
+      message: 'timeout of 0ms exceeded',
+      variant: 'danger',
+    };
+    expect(store.getters.status).to.deep.include(afterExpectedStatus);
+  });
+
+  it('should show error message on API call 500 response', async () => {
+    mock.restore();
+    mock = new AxiosMockAdapter(axios);
+    mock.onGet(PARAMETER_SET_URL).reply(200, MOCK_DATA);
+    mock.onPut(PARAMETER_URL).reply(500, {});
+    // Wait for asynchronous API call to get parameter set
+    await localVue.nextTick();
+    // Now wait for API response
+    await localVue.nextTick();
+    // Now wait for render
+    await localVue.nextTick();
+    const parameterDraggable = wrapper.findComponent(draggable);
+    expect(mock.history.put.length).to.equal(0);
+    const changeData = {
+      moved: {
+        element: wrapper.vm.parameterSet.parameters[0],
+        oldIndex: 0,
+        newIndex: 1,
+      },
+    };
+    parameterDraggable.vm.$emit('change', changeData);
+    // Await API call
+    await localVue.nextTick();
+    const beforeExpectedStatus = {
+      message: 'Welcome',
+      variant: 'info',
+    };
+    expect(store.getters.status).to.eql(beforeExpectedStatus);
+    // Render after API response
+    await flushPromises();
+    const afterExpectedStatus = {
+      message: 'Request failed with status code 500',
+      variant: 'danger',
+    };
+    expect(store.getters.status).to.deep.include(afterExpectedStatus);
+  });
+});

--- a/tests/unit/tconfig.spec.js
+++ b/tests/unit/tconfig.spec.js
@@ -4,10 +4,9 @@ import Vuex from 'vuex';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
 import { expect } from 'chai';
 import { createLocalVue, mount } from '@vue/test-utils';
-import axios from 'axios';
-import AxiosMockAdapter from 'axios-mock-adapter';
 import Tconfig from '@/components/Tconfig.vue';
 import ParameterSet from '@/components/ParameterSet.vue';
+import Configurations from '@/components/Configurations.vue';
 import state from '@/store/state';
 import getters from '@/store/getters';
 import mutations from '@/store/mutations';
@@ -17,88 +16,11 @@ localVue.use(Vuex);
 localVue.use(BootstrapVue);
 localVue.use(IconsPlugin);
 
-const API_PREFIX = 'http://localhost:5000/tconfig/api/v1/';
-const PARAMETER_SET_URL = API_PREFIX.concat('parameterset/');
-const PARAMETER_URL = API_PREFIX.concat('parameters/');
-
-const MOCK_PARAMETER_SET = {
-  name: null,
-  parameters: [
-    {
-      excluded: [],
-      excluded_by: [],
-      name: 'Colour',
-      parameter_set: 1,
-      position: 0,
-      uid: 1,
-      values: [
-        {
-          name: 'Red',
-          parameter: 1,
-          position: 0,
-          uid: 1,
-        },
-        {
-          name: 'Green',
-          parameter: 1,
-          position: 1,
-          uid: 2,
-        },
-      ],
-    },
-    {
-      excluded: [],
-      excluded_by: [],
-      name: 'Pet',
-      parameter_set: 1,
-      position: 1,
-      uid: 2,
-      values: [
-        {
-          name: 'Bird',
-          parameter: 2,
-          position: 0,
-          uid: 3,
-        },
-        {
-          name: 'Cat',
-          parameter: 2,
-          position: 1,
-          uid: 4,
-        },
-        {
-          name: 'Dog',
-          parameter: 2,
-          position: 2,
-          uid: 5,
-        },
-        {
-          name: 'Fish',
-          parameter: 2,
-          position: 3,
-          uid: 6,
-        },
-      ],
-    },
-  ],
-  position: null,
-  uid: 1,
-};
-
-const MOCK_DATA = {
-  parameter_list_url: PARAMETER_URL,
-  parameter_set: MOCK_PARAMETER_SET,
-  parameter_set_url: PARAMETER_SET_URL,
-};
-
 describe('Tconfig.vue', () => {
   let wrapper;
   let store;
-  let mock;
 
   beforeEach(() => {
-    mock = new AxiosMockAdapter(axios);
-    mock.onGet(PARAMETER_SET_URL).reply(200, MOCK_DATA);
     store = new Vuex.Store({
       state,
       getters,
@@ -108,10 +30,6 @@ describe('Tconfig.vue', () => {
       store,
       localVue,
     });
-  });
-
-  afterEach(() => {
-    mock.restore();
   });
 
   it('should have header "Test Configuration Generator"', () => {
@@ -134,20 +52,15 @@ describe('Tconfig.vue', () => {
     expect(wrapper.text()).to.include(msg);
   });
 
-  it('should load a parameter set on creation"', async () => {
-    // Wait for asynchronous API call to get parameter set
-    await localVue.nextTick();
-    expect(mock.history.get.length).to.equal(1);
-    // Now wait for render from API response
-    await localVue.nextTick();
-    // Expect that the 'parameter_set' attribute of response is stored.
-    // Check object equivalence, not identity
-    expect(wrapper.vm.parameterSet).to.eql(MOCK_DATA.parameter_set);
-  });
-
-  it('should have 1 parameter set component"', () => {
+  it('should have 1 parameter set component', () => {
     const psets = wrapper.findAllComponents(ParameterSet);
     expect(psets.length).to.equal(1);
     expect(psets.is(ParameterSet)).to.equal(true);
+  });
+
+  it('should have 1 configurations component', () => {
+    const configs = wrapper.findAllComponents(Configurations);
+    expect(configs.length).to.equal(1);
+    expect(configs.is(Configurations)).to.equal(true);
   });
 });


### PR DESCRIPTION
- Add some unit tests for ``ParameterSet.vue`` component, including API call on load and parameter re-ordering
- When generating configurations, parameter set is obtained from Vuex store instead of prop passed down from ``Tconfig`` component.
- Moved scope of `parameterSet` computed value from store to `ParameterSet` Vue component, since it no longer needs to be at top-level ``Tconfig.vue`` scope with Vuex store.
- Added better logging of API call errors, after being able to mock responses
